### PR TITLE
feat(architecture): Added automated dependency KPIs reports

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,0 +1,395 @@
+/** @type {import('dependency-cruiser').IConfiguration} */
+module.exports = {
+  forbidden: [
+    {
+      name: 'no-circular',
+      severity: 'warn',
+      comment:
+        'This dependency is part of a circular relationship. You might want to revise ' +
+        'your solution (i.e. use dependency inversion, make sure the modules have a single responsibility) ',
+      from: {},
+      to: {
+        circular: true
+      }
+    },
+    {
+      name: 'no-orphans',
+      comment:
+        "This is an orphan module - it's likely not used (anymore?). Either use it or " +
+        "remove it. If it's logical this module is an orphan (i.e. it's a config file), " +
+        "add an exception for it in your dependency-cruiser configuration. By default " +
+        "this rule does not scrutinize dot-files (e.g. .eslintrc.js), TypeScript declaration " +
+        "files (.d.ts), tsconfig.json and some of the babel and webpack configs.",
+      severity: 'warn',
+      from: {
+        orphan: true,
+        pathNot: [
+          '(^|/)[.][^/]+[.](?:js|cjs|mjs|ts|cts|mts|json)$',                  // dot files
+          '[.]d[.]ts$',                                                       // TypeScript declaration files
+          '(^|/)tsconfig[.]json$',                                            // TypeScript config
+          '(^|/)(?:babel|webpack)[.]config[.](?:js|cjs|mjs|ts|cts|mts|json)$' // other configs
+        ]
+      },
+      to: {},
+    },
+    {
+      name: 'no-deprecated-core',
+      comment:
+        'A module depends on a node core module that has been deprecated. Find an alternative - these are ' +
+        "bound to exist - node doesn't deprecate lightly.",
+      severity: 'warn',
+      from: {},
+      to: {
+        dependencyTypes: [
+          'core'
+        ],
+        path: [
+          '^v8/tools/codemap$',
+          '^v8/tools/consarray$',
+          '^v8/tools/csvparser$',
+          '^v8/tools/logreader$',
+          '^v8/tools/profile_view$',
+          '^v8/tools/profile$',
+          '^v8/tools/SourceMap$',
+          '^v8/tools/splaytree$',
+          '^v8/tools/tickprocessor-driver$',
+          '^v8/tools/tickprocessor$',
+          '^node-inspect/lib/_inspect$',
+          '^node-inspect/lib/internal/inspect_client$',
+          '^node-inspect/lib/internal/inspect_repl$',
+          '^async_hooks$',
+          '^punycode$',
+          '^domain$',
+          '^constants$',
+          '^sys$',
+          '^_linklist$',
+          '^_stream_wrap$'
+        ],
+      }
+    },
+    {
+      name: 'not-to-deprecated',
+      comment:
+        'This module uses a (version of an) npm module that has been deprecated. Either upgrade to a later ' +
+        'version of that module, or find an alternative. Deprecated modules are a security risk.',
+      severity: 'warn',
+      from: {},
+      to: {
+        dependencyTypes: [
+          'deprecated'
+        ]
+      }
+    },
+    {
+      name: 'no-non-package-json',
+      severity: 'error',
+      comment:
+        "This module depends on an npm package that isn't in the 'dependencies' section of your package.json. " +
+        "That's problematic as the package either (1) won't be available on live (2 - worse) will be " +
+        "available on live with an non-guaranteed version. Fix it by adding the package to the dependencies " +
+        "in your package.json.",
+      from: {},
+      to: {
+        dependencyTypes: [
+          'npm-no-pkg',
+          'npm-unknown'
+        ]
+      }
+    },
+    {
+      name: 'not-to-unresolvable',
+      comment:
+        "This module depends on a module that cannot be found ('resolved to disk'). If it's an npm " +
+        'module: add it to your package.json. In all other cases you likely already know what to do.',
+      severity: 'error',
+      from: {},
+      to: {
+        couldNotResolve: true
+      }
+    },
+    {
+      name: 'no-duplicate-dep-types',
+      comment:
+        "Likely this module depends on an external ('npm') package that occurs more than once " +
+        "in your package.json i.e. bot as a devDependencies and in dependencies. This will cause " +
+        "maintenance problems later on.",
+      severity: 'warn',
+      from: {},
+      to: {
+        moreThanOneDependencyType: true,
+        // as it's pretty common to have a type import be a type only import 
+        // _and_ (e.g.) a devDependency - don't consider type-only dependency
+        // types for this rule
+        dependencyTypesNot: ["type-only"]
+      }
+    },
+
+    /* rules you might want to tweak for your specific situation: */
+    
+    {
+      name: 'not-to-spec',
+      comment:
+        'This module depends on a spec (test) file. The sole responsibility of a spec file is to test code. ' +
+        "If there's something in a spec that's of use to other modules, it doesn't have that single " +
+        'responsibility anymore. Factor it out into (e.g.) a separate utility/ helper or a mock.',
+      severity: 'error',
+      from: {},
+      to: {
+        path: '[.](?:spec|test)[.](?:js|mjs|cjs|jsx|ts|mts|cts|tsx)$'
+      }
+    },
+    {
+      name: 'not-to-dev-dep',
+      severity: 'error',
+      comment:
+        "This module depends on an npm package from the 'devDependencies' section of your " +
+        'package.json. It looks like something that ships to production, though. To prevent problems ' +
+        "with npm packages that aren't there on production declare it (only!) in the 'dependencies'" +
+        'section of your package.json. If this module is development only - add it to the ' +
+        'from.pathNot re of the not-to-dev-dep rule in the dependency-cruiser configuration',
+      from: {
+        path: '^(src)',
+        pathNot: '[.](?:spec|test)[.](?:js|mjs|cjs|jsx|ts|mts|cts|tsx)$'
+      },
+      to: {
+        dependencyTypes: [
+          'npm-dev',
+        ],
+        // type only dependencies are not a problem as they don't end up in the
+        // production code or are ignored by the runtime.
+        dependencyTypesNot: [
+          'type-only'
+        ],
+        pathNot: [
+          'node_modules/@types/'
+        ]
+      }
+    },
+    {
+      name: 'optional-deps-used',
+      severity: 'info',
+      comment:
+        "This module depends on an npm package that is declared as an optional dependency " +
+        "in your package.json. As this makes sense in limited situations only, it's flagged here. " +
+        "If you're using an optional dependency here by design - add an exception to your" +
+        "dependency-cruiser configuration.",
+      from: {},
+      to: {
+        dependencyTypes: [
+          'npm-optional'
+        ]
+      }
+    },
+    {
+      name: 'peer-deps-used',
+      comment:
+        "This module depends on an npm package that is declared as a peer dependency " +
+        "in your package.json. This makes sense if your package is e.g. a plugin, but in " +
+        "other cases - maybe not so much. If the use of a peer dependency is intentional " +
+        "add an exception to your dependency-cruiser configuration.",
+      severity: 'warn',
+      from: {},
+      to: {
+        dependencyTypes: [
+          'npm-peer'
+        ]
+      }
+    }
+  ],
+  options: {
+
+    /* Which modules not to follow further when encountered */
+    doNotFollow: {
+      /* path: an array of regular expressions in strings to match against */
+      path: ['node_modules']
+    },
+
+    /* Which modules to exclude */
+    // exclude : {
+    //   /* path: an array of regular expressions in strings to match against */
+    //   path: '',
+    // },
+
+    /* Which modules to exclusively include (array of regular expressions in strings)
+       dependency-cruiser will skip everything not matching this pattern
+    */
+    // includeOnly : [''],
+
+    /* List of module systems to cruise.
+       When left out dependency-cruiser will fall back to the list of _all_
+       module systems it knows of. It's the default because it's the safe option
+       It might come at a performance penalty, though.
+       moduleSystems: ['amd', 'cjs', 'es6', 'tsd']
+      
+       As in practice only commonjs ('cjs') and ecmascript modules ('es6')
+       are widely used, you can limit the moduleSystems to those.
+     */
+    
+    // moduleSystems: ['cjs', 'es6'],
+
+    /* 
+      false: don't look at JSDoc imports (the default)
+      true: dependency-cruiser will detect dependencies in JSDoc-style
+      import statements. Implies "parser": "tsc", so the dependency-cruiser
+      will use the typescript parser for JavaScript files.
+     
+      For this to work the typescript compiler will need to be installed in the
+      same spot as you're running dependency-cruiser from.
+     */
+    detectJSDocImports: true,
+
+    /* prefix for links in html and svg output (e.g. 'https://github.com/you/yourrepo/blob/main/'
+       to open it on your online repo or `vscode://file/${process.cwd()}/` to 
+       open it in visual studio code),
+     */
+    // prefix: `vscode://file/${process.cwd()}/`,
+
+    /* false (the default): ignore dependencies that only exist before typescript-to-javascript compilation
+       true: also detect dependencies that only exist before typescript-to-javascript compilation
+       "specify": for each dependency identify whether it only exists before compilation or also after
+     */
+    tsPreCompilationDeps: true,
+    
+    /* list of extensions to scan that aren't javascript or compile-to-javascript.
+       Empty by default. Only put extensions in here that you want to take into
+       account that are _not_ parsable.
+    */
+    // extraExtensionsToScan: [".json", ".jpg", ".png", ".svg", ".webp"],
+
+    /* if true combines the package.jsons found from the module up to the base
+       folder the cruise is initiated from. Useful for how (some) mono-repos
+       manage dependencies & dependency definitions.
+     */
+    // combinedDependencies: false,
+
+    /* if true leave symlinks untouched, otherwise use the realpath */
+    // preserveSymlinks: false,
+
+    /* TypeScript project file ('tsconfig.json') to use for
+       (1) compilation and
+       (2) resolution (e.g. with the paths property)
+
+       The (optional) fileName attribute specifies which file to take (relative to
+       dependency-cruiser's current working directory). When not provided
+       defaults to './tsconfig.json'.
+     */
+    tsConfig: {
+      fileName: 'tsconfig.json'
+    },
+
+    /* Webpack configuration to use to get resolve options from.
+
+       The (optional) fileName attribute specifies which file to take (relative
+       to dependency-cruiser's current working directory. When not provided defaults
+       to './webpack.conf.js'.
+
+       The (optional) `env` and `arguments` attributes contain the parameters
+       to be passed if your webpack config is a function and takes them (see 
+        webpack documentation for details)
+     */
+    // webpackConfig: {
+    //  fileName: 'webpack.config.js',
+    //  env: {},
+    //  arguments: {}
+    // },
+
+    /* Babel config ('.babelrc', '.babelrc.json', '.babelrc.json5', ...) to use
+      for compilation
+     */
+    // babelConfig: {
+    //   fileName: '.babelrc',
+    // },
+
+    /* List of strings you have in use in addition to cjs/ es6 requires
+       & imports to declare module dependencies. Use this e.g. if you've
+       re-declared require, use a require-wrapper or use window.require as
+       a hack.
+    */
+    // exoticRequireStrings: [],
+    
+    /* options to pass on to enhanced-resolve, the package dependency-cruiser
+       uses to resolve module references to disk. The values below should be
+       suitable for most situations
+
+       If you use webpack: you can also set these in webpack.conf.js. The set
+       there will override the ones specified here.
+     */
+    enhancedResolveOptions: {
+      /* What to consider as an 'exports' field in package.jsons */ 
+      exportsFields: ["exports"],
+      /* List of conditions to check for in the exports field.
+         Only works when the 'exportsFields' array is non-empty.
+      */
+      conditionNames: ["import", "require", "node", "default", "types"],
+      /* The extensions, by default are the same as the ones dependency-cruiser
+         can access (run `npx depcruise --info` to see which ones that are in
+         _your_ environment). If that list is larger than you need you can pass
+         the extensions you actually use (e.g. [".js", ".jsx"]). This can speed
+         up module resolution, which is the most expensive step.
+       */
+      // extensions: [".js", ".jsx", ".ts", ".tsx", ".d.ts"],
+      /* What to consider a 'main' field in package.json */
+      mainFields: ["module", "main", "types", "typings"],
+      /* A list of alias fields in package.jsons
+        
+         See [this specification](https://github.com/defunctzombie/package-browser-field-spec) and
+         the webpack [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealiasfields)
+         documentation.
+         
+         Defaults to an empty array (= don't use alias fields).
+       */
+      // aliasFields: ["browser"],
+    },
+
+    /* skipAnalysisNotInRules will make dependency-cruiser execute 
+       analysis strictly necessary for checking the rule set only. 
+
+       See https://github.com/sverweij/dependency-cruiser/blob/main/doc/options-reference.md#skipanalysisnotinrules
+       for details
+     */
+    skipAnalysisNotInRules: true,
+    
+    reporterOptions: {
+      dot: {
+        /* pattern of modules that can be consolidated in the detailed
+           graphical dependency graph. The default pattern in this configuration
+           collapses everything in node_modules to one folder deep so you see
+           the external modules, but their innards.
+         */
+        collapsePattern: 'node_modules/(?:@[^/]+/[^/]+|[^/]+)',
+
+        /* Options to tweak the appearance of your graph.See
+           https://github.com/sverweij/dependency-cruiser/blob/main/doc/options-reference.md#reporteroptions
+           for details and some examples. If you don't specify a theme
+           dependency-cruiser falls back to a built-in one.
+        */
+        // theme: {
+        //   graph: {
+        //     /* splines: "ortho" gives straight lines, but is slow on big graphs
+        //        splines: "true" gives bezier curves (fast, not as nice as ortho)
+        //    */
+        //     splines: "true"
+        //   },
+        // }
+      },
+      archi: {
+        /* pattern of modules that can be consolidated in the high level
+           graphical dependency graph. If you use the high level graphical
+           dependency graph reporter (`archi`) you probably want to tweak
+           this collapsePattern to your situation.
+        */
+        collapsePattern: '^(?:packages|src|lib(s?)|app(s?)|bin|test(s?)|spec(s?))/[^/]+|node_modules/(?:@[^/]+/[^/]+|[^/]+)',
+
+        /* Options to tweak the appearance of your graph. If you don't specify a
+           theme for 'archi' dependency-cruiser will use the one specified in the
+           dot section above and otherwise use the default one.
+         */
+        // theme: { },
+      },
+      "text": {
+        "highlightFocused": true
+      },
+    }
+  }
+};
+// generated: dependency-cruiser@16.10.2 on 2025-06-02T13:39:28.440Z

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ docker/ssl/*.crt
 docker/ssl/*.key
 docker/ssl/*.pem
 .npmrc
+/dependency-graph*.*

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -14,7 +14,7 @@ npx tsc --noEmit
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(js|jsx|ts|tsx)$' | tr '\n' ' ')
 if [ -n "$STAGED_FILES" ]; then
   echo "🧪 Ejecutando tests..."
-  npx jest --bail --findRelatedTests $STAGED_FILES
+  npx jest --bail --findRelatedTests --passWithNoTests $STAGED_FILES
 fi
 
 echo "🧪 Ejecutando linter..."

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "css-loader": "^6.10.0",
         "cypress": "^14.3.0",
         "cz-conventional-changelog": "^3.3.0",
+        "dependency-cruiser": "^16.10.2",
         "dotenv": "^16.5.0",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
@@ -5523,6 +5524,26 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-jsx-walk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx-walk/-/acorn-jsx-walk-2.0.0.tgz",
+      "integrity": "sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn-loose": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.0.tgz",
+      "integrity": "sha512-ppga7pybjwX2HSJv5ayHe6QG4wmNS1RQ2wjBMFTVnOj0h8Rxsmtc6fnVzINqHSSRz23sTe9IL3UAt/PU9gc4FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
@@ -8519,6 +8540,111 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dependency-cruiser": {
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/dependency-cruiser/-/dependency-cruiser-16.10.2.tgz",
+      "integrity": "sha512-3tvyt9g3QV6iD6SLC+71bYZnKGTxHo/8dJeguhTgB2T0ui9k/6BbFlibrFYSlb7WeNHS1OlKUFY+BEQ1+w8gvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.14.1",
+        "acorn-jsx": "^5.3.2",
+        "acorn-jsx-walk": "^2.0.0",
+        "acorn-loose": "^8.5.0",
+        "acorn-walk": "^8.3.4",
+        "ajv": "^8.17.1",
+        "commander": "^13.1.0",
+        "enhanced-resolve": "^5.18.1",
+        "ignore": "^7.0.4",
+        "interpret": "^3.1.1",
+        "is-installed-globally": "^1.0.0",
+        "json5": "^2.2.3",
+        "memoize": "^10.1.0",
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.2",
+        "prompts": "^2.4.2",
+        "rechoir": "^0.8.0",
+        "safe-regex": "^2.1.1",
+        "semver": "^7.7.1",
+        "teamcity-service-messages": "^0.1.14",
+        "tsconfig-paths-webpack-plugin": "^4.2.0",
+        "watskeburt": "^4.2.3"
+      },
+      "bin": {
+        "depcruise": "bin/dependency-cruise.mjs",
+        "depcruise-baseline": "bin/depcruise-baseline.mjs",
+        "depcruise-fmt": "bin/depcruise-fmt.mjs",
+        "depcruise-wrap-stream-in-html": "bin/wrap-stream-in-html.mjs",
+        "dependency-cruise": "bin/dependency-cruise.mjs",
+        "dependency-cruiser": "bin/dependency-cruise.mjs"
+      },
+      "engines": {
+        "node": "^18.17||>=20"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dependency-cruiser/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/deprecation": {
@@ -15801,6 +15927,22 @@
         "url": "https://github.com/sponsors/streamich"
       }
     },
+    "node_modules/memoize": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.1.0.tgz",
+      "integrity": "sha512-MMbFhJzh4Jlg/poq1si90XRlTZRDHVqdlz2mPyGJ6kqMpyHUyVpDd5gpFAvVehW64+RA1eKE9Yt8aSLY7w2Kgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/memoize?sponsor=1"
+      }
+    },
     "node_modules/meow": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
@@ -19140,6 +19282,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -19500,6 +19652,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
       }
     },
     "node_modules/safe-regex-test": {
@@ -21322,6 +21484,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/teamcity-service-messages": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/teamcity-service-messages/-/teamcity-service-messages-0.1.14.tgz",
+      "integrity": "sha512-29aQwaHqm8RMX74u2o/h1KbMLP89FjNiMxD9wbF2BbWOnbM+q+d1sCEC+MqCc4QW3NJykn77OMpTFw/xTHIc0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -21876,6 +22045,47 @@
         "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.2.0.tgz",
+      "integrity": "sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tapable": "^2.2.1",
+        "tsconfig-paths": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
@@ -22497,6 +22707,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/watskeburt": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/watskeburt/-/watskeburt-4.2.3.tgz",
+      "integrity": "sha512-uG9qtQYoHqAsnT711nG5iZc/8M5inSmkGCOp7pFaytKG2aTfIca7p//CjiVzAE4P7hzaYuCozMjNNaLgmhbK5g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "watskeburt": "dist/run-cli.js"
+      },
+      "engines": {
+        "node": "^18||>=20"
       }
     },
     "node_modules/wbuf": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "css-loader": "^6.10.0",
     "cypress": "^14.3.0",
     "cz-conventional-changelog": "^3.3.0",
+    "dependency-cruiser": "^16.10.2",
     "dotenv": "^16.5.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
@@ -114,7 +115,10 @@
     "docker:up": "docker compose -f docker/docker-compose.yml up",
     "docker:up:build": "docker compose -f docker/docker-compose.yml up --build",
     "docker:down": "docker compose -f docker/docker-compose.yml down -v --remove-orphans",
-    "docker:reset": "docker compose -f docker/docker-compose.yml down -v --rmi all --remove-orphans"
+    "docker:reset": "docker compose -f docker/docker-compose.yml down -v --rmi all --remove-orphans",
+    "depcruise:dot": "node scripts/generate-dot.js",
+    "depcruise:svg": "dot -Tsvg dependency-graph.dot -o dependency-graph.svg",
+    "depcruise:kpi": "node scripts/depcruise-kpi.js"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/scripts/depcruise-kpi.js
+++ b/scripts/depcruise-kpi.js
@@ -1,0 +1,109 @@
+import { execSync } from 'child_process';
+
+const SRC = 'src';
+
+const depcruiseJson = execSync(`npx depcruise --output-type json ${SRC}`, { encoding: 'utf8' });
+const report = JSON.parse(depcruiseJson);
+
+// Número de ciclos
+const cycles =
+  (report.summary && report.summary.cycleCount) || (report.cycles ? report.cycles.length : 0);
+
+// Profundidad máxima de dependencias
+const maxDepth = (report.summary && report.summary.maxDepth) || 0;
+
+// Módulos huérfanos
+const orphanModules = (report.orphanModules && report.orphanModules.length) || 0;
+const totalModules = (report.modules && report.modules.length) || 1;
+const orphanPercent = ((orphanModules / totalModules) * 100).toFixed(2);
+
+// Fan-in y fan-out
+let maxFanIn = 0,
+  maxFanOut = 0;
+let maxFanInModules = [];
+let maxFanOutModules = [];
+
+report.modules.forEach(mod => {
+  const fanOut = mod.dependencies ? mod.dependencies.length : 0;
+  const fanIn = mod.dependents ? mod.dependents.length : 0;
+
+  if (fanOut > maxFanOut) {
+    maxFanOut = fanOut;
+    maxFanOutModules = [mod.source];
+  } else if (fanOut === maxFanOut && fanOut > 0) {
+    maxFanOutModules.push(mod.source);
+  }
+
+  if (fanIn > maxFanIn) {
+    maxFanIn = fanIn;
+    maxFanInModules = [mod.source];
+  } else if (fanIn === maxFanIn && fanIn > 0) {
+    maxFanInModules.push(mod.source);
+  }
+});
+
+// Violaciones de reglas de arquitectura (detalladas)
+let ruleViolations = [];
+if (report.modules) {
+  report.modules.forEach(mod => {
+    if (mod.dependencies) {
+      mod.dependencies.forEach(dep => {
+        if (dep.valid === false && dep.rules) {
+          dep.rules.forEach(rule => {
+            ruleViolations.push({
+              from: mod.source,
+              to: dep.resolved,
+              rule: rule.name,
+              severity: rule.severity,
+              comment: rule.comment,
+              explanation: rule.explanation,
+            });
+          });
+        }
+      });
+    }
+  });
+}
+
+// Nombres de módulos huérfanos
+const orphanModuleNames = report.orphanModules || [];
+
+// Ciclos detectados
+const cyclesList = (report.cycles || []).map(cycle => (cycle.cyclePath ? cycle.cyclePath : cycle));
+
+console.log('--- Dependency KPIs ---');
+console.log(`Cycles: ${cycles}`);
+if (cyclesList.length > 0) {
+  console.log('Cycle details:');
+  cyclesList.forEach((cycle, idx) => {
+    console.log(`  Cycle ${idx + 1}: ${cycle.join(' -> ')} -> ${cycle[0]}`);
+  });
+}
+console.log(`Max dependency depth: ${maxDepth}`);
+console.log(`Orphan modules: ${orphanModules} (${orphanPercent}%)`);
+if (orphanModuleNames.length > 0) {
+  console.log('Orphan module names:');
+  orphanModuleNames.forEach(name => console.log(`  - ${name}`));
+}
+console.log(`Max fan-in: ${maxFanIn}`);
+if (maxFanInModules.length > 0) {
+  console.log('Modules with max fan-in:');
+  maxFanInModules.forEach(name => console.log(`  - ${name}`));
+}
+console.log(`Max fan-out: ${maxFanOut}`);
+if (maxFanOutModules.length > 0) {
+  console.log('Modules with max fan-out:');
+  maxFanOutModules.forEach(name => console.log(`  - ${name}`));
+}
+console.log(`Architecture rule violations: ${ruleViolations.length}`);
+if (ruleViolations.length > 0) {
+  console.log('Rule violation details:');
+  ruleViolations.forEach((v, idx) => {
+    console.log(`  ${idx + 1}. [${v.severity}] Rule: "${v.rule}"`);
+    console.log(`     From: ${v.from}`);
+    console.log(`     To:   ${v.to}`);
+    if (v.comment) console.log(`     Comment: ${v.comment}`);
+    if (v.explanation) console.log(`     Explanation: ${v.explanation}`);
+  });
+}
+console.log('-----------------------');

--- a/scripts/generate-dot.js
+++ b/scripts/generate-dot.js
@@ -1,0 +1,6 @@
+import { execSync } from 'child_process';
+import { writeFileSync } from 'fs';
+
+const output = execSync('npx depcruise --output-type dot src', { encoding: 'utf8' });
+writeFileSync('dependency-graph.dot', output, { encoding: 'utf8', flag: 'w' });
+console.log('dependency-graph.dot generated (UTF-8 without BOM)');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,16 @@
       "@shared/*": ["shared/*"]
     }
   },
-  "include": ["cypress/**/*.ts", "src/**/*", "commitlint.config.js", "setupTests.ts", "jest.config.js", "cypress.config.js", "checkCoverage.mjs", "webpack.config.js"],
+  "include": [
+    "cypress/**/*.ts",
+    "src/**/*",
+    "commitlint.config.js",
+    "setupTests.ts",
+    "jest.config.js",
+    "cypress.config.js",
+    "checkCoverage.mjs",
+    "webpack.config.js",
+    "scripts/**/*.js"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Added automated dependency KPIs and architecture rulues

- Integrate dependency-cruiser for advanced dependency analysis
- Add script to calculate and display KPIs: cycles, max depth, orphan modules, fan-in, and fan-out
- Report rule violations and show modules with highest fan-in, fan-out, and orphan status
- Document and interpret results to improve codebase maintainability