### PR TITLE
chore(lerna): restrict versioning and publishing to main branch only

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -55,7 +55,7 @@
           }
         ]
       },
-      "allowBranch": ["main", "feature/*", "fix/*"],
+      "allowBranch": ["main"],
       "ignoreChanges": [
         "**/*.md",
         "**/test/**",
@@ -75,7 +75,7 @@
       "conventionalCommits": true,
       "createRelease": "github",
       "message": "chore(release): %s [skip ci]",
-      "allowBranch": ["feature/*", "fix/*"],
+      "allowBranch": ["main"],
       "ignoreChanges": ["**/*.md", "**/test/**", "**/tests/**", "**/__tests__/**", "**/coverage/**"]
     }
   }


### PR DESCRIPTION
- Update allowBranch in lerna.json to ['main'] for both version and publish commands
- Prevents accidental releases from feature or fix branches and enforces release policy