### PR TITLE
chore(workflows): remove skip ci token and improve workflow handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
           setup-git-identity: true
       - run: npm run build
       - name: Version packages
+        if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
         run: npx lerna version --yes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.husky/pre-commit.js
+++ b/.husky/pre-commit.js
@@ -5,8 +5,8 @@ try {
   const commitMsg = execSync('git log -1 --pretty=%B').toString().trim();
   console.log('Commit message:', commitMsg);
 
-  // Skip for Lerna version commits
-  if (commitMsg.includes('[skip ci]')) {
+  // Skip for Lerna version commits (detect 'chore(release):')
+  if (/^chore\(release\):/i.test(commitMsg)) {
     console.log('⏩ Pre-commit hook skipped for Lerna version commit.');
     process.exit(0);
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @acamae/frontend
 
-## 0.10.10 (2025-06-19)
-
-**Note:** Version bump only for package @acamae/frontend
-
 ## 0.10.9 (2025-06-19)
-
-**Note:** Version bump only for package @acamae/frontend
-
-## 0.10.9 (2025-06-19)
-
-**Note:** Version bump only for package @acamae/frontend
-
-## 0.10.8 (2025-06-19)
 
 **Note:** Version bump only for package @acamae/frontend
 
@@ -30,16 +18,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## [0.10.7](https://github.com/acamae/acamae-frontend/compare/v0.10.6...v0.10.7) (2025-06-18)
 
 **Note:** Version bump only for package @acamae/frontend
-
-## [0.10.7](https://github.com/acamae/acamae-frontend/compare/v0.10.6...v0.10.7) (2025-06-18)
-
-**Note:** Version bump only for package @acamae/frontend
-
-## <small>0.10.6 (2025-06-18)</small>
-
-- fix(ci): improve GitHub Actions workflow robustness and reliability ([d294595](https://github.com/acamae/acamae-frontend/commit/d294595))
-- fix(ci): resolve CHANGELOG duplication with simplified Lerna workflow ([4d060fc](https://github.com/acamae/acamae-frontend/commit/4d060fc))
-- chore(ci): add Lerna debug mode for changelog investigation ([1ac3d80](https://github.com/acamae/acamae-frontend/commit/1ac3d80))
 
 ## <small>0.10.6 (2025-06-18)</small>
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ npm run update:snapshots
 #### Husky + lint-staged
 
 - **Pre-commit**:
-  - Skips automatically on Lerna versioning commits (detects `[skip ci]` in the message).
+  - Skips automatically on Lerna versioning commits (detects commit messages that start with `chore(release):`).
   - Type checking with TypeScript (`tsc --noEmit`).
   - Runs unit tests only on staged files.
   - Linter and auto-formatting on staged files via lint-staged (ESLint and Prettier).

--- a/lerna.json
+++ b/lerna.json
@@ -74,7 +74,7 @@
       "skipChangelog": false,
       "conventionalCommits": true,
       "createRelease": "github",
-      "message": "chore(release): %s [skip ci]",
+      "message": "chore(release): %s",
       "allowBranch": ["release"],
       "ignoreChanges": ["**/*.md", "**/test/**", "**/tests/**", "**/__tests__/**", "**/coverage/**"]
     }


### PR DESCRIPTION
- Drop [skip ci] from Lerna version message to avoid skipped PR workflows
- Add guard in release.yml to skip lerna version on release commit
- Update pre-commit hook to detect chore(release): prefix instead of [skip ci]
- Refresh README with new pre-commit logic
- Deduplicate entries in CHANGELOG.md